### PR TITLE
The problem with commit transaction after assimilate

### DIFF
--- a/C# Item Templates/Revit 2017 External Command/ExternalCommand.cs
+++ b/C# Item Templates/Revit 2017 External Command/ExternalCommand.cs
@@ -95,7 +95,6 @@ namespace $rootnamespace${
                             elements)) {
 
                             tr_gr.Assimilate();
-                            tr_gr.Commit();
                             result = Result.Succeeded;
                         }
                         else {


### PR DESCRIPTION
Transaction assimilate involves the merge of commiting transaction so it is not required. Need to delete tr_gr.Commit().